### PR TITLE
Enable layered effect creation

### DIFF
--- a/polychromatic/controller/effects.py
+++ b/polychromatic/controller/effects.py
@@ -147,8 +147,8 @@ class EffectsTab(shared.CommonFileTab):
         btn_scripted.clicked.connect(lambda: self.new_file_stage_2(dialog, effects.TYPE_SCRIPTED))
         btn_sequence.clicked.connect(lambda: self.new_file_stage_2(dialog, effects.TYPE_SEQUENCE))
 
-        # FIXME: Not yet implemented editors
-        btn_layered.setEnabled(False)
+        # FIXME: Scripted editor is not yet implemented
+        # leave the "Layered" option enabled so it can be selected
         btn_scripted.setEnabled(False)
 
         dialog.open()


### PR DESCRIPTION
## Summary
- allow selecting `Layered` when creating a new effect
- update comment to note the scripted editor is still disabled

## Testing
- `./tests/run.sh` *(fails: could not set up locale for tests)*

------
https://chatgpt.com/codex/tasks/task_e_686a31977abc8333abc6e6759fe4bf5c